### PR TITLE
Updated newrelic_rpm

### DIFF
--- a/padrino-rpm.gemspec
+++ b/padrino-rpm.gemspec
@@ -16,6 +16,6 @@ Gem::Specification.new do |s|
   s.summary = %q{Padrino Instrumentation for New Relic RPM}
   s.files = `git ls-files`.split("\n")
 
-  s.add_dependency(%q<newrelic_rpm>, "~> 3.3.3")
+  s.add_dependency(%q<newrelic_rpm>, "~> 3.5.3")
 end
 


### PR DESCRIPTION
Switching to an updated version of newrelic_rpm because of security flaw in prior versions.

[Ruby Agent Security Notification](https://newrelic.com/docs/ruby/ruby-agent-security-notification)
